### PR TITLE
Feature/pusher proxy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ python:
     - "3.6"
 
 env:
+  global:
+    - SECRET_KEY=superSecretKey
+  matrix:
     - DJANGO_VERSION=1.10
     - DJANGO_VERSION=1.11
     - DJANGO_VERSION=2.0

--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ The PusherBackend.push_change method accepts an `ignore` boolean keyword argumen
 
 ### Settings
 
-- `DRF_MODEL_PUSHER_BACKENDS_FILE` - The file in your applications to import PusherBackends.
+- `DRF_MODEL_PUSHER_BACKENDS_FILE` (default: `pusher_backends.py`) - The file in your applications to import PusherBackends.
+- `DRF_MODEL_PUSHER_DISABLED` (default: `False`) - Determines whether or not to trigger Pusher events.
 
 ## Common Issues
 ### Unregistered Backends

--- a/drf_model_pusher/proxies.py
+++ b/drf_model_pusher/proxies.py
@@ -1,0 +1,20 @@
+from django.conf import settings
+from pusher import Pusher
+
+
+class PusherProxy(object):
+    """
+    This class provides a wrapper to Pusher so that we can mock it or disable it easily
+    """
+    def __init__(self, *args, **kwargs):
+        self._pusher = Pusher(*args, **kwargs)
+        self._disabled = False
+
+        if hasattr(settings, "DRF_MODEL_PUSHER_DISABLED"):
+            self._disabled = settings.DRF_MODEL_PUSHER_DISABLED
+
+    def trigger(self, channels, event_name, data):
+        if self._disabled:
+            return
+
+        self._pusher.trigger(channels, event_name, data)

--- a/drf_model_pusher/receivers.py
+++ b/drf_model_pusher/receivers.py
@@ -1,5 +1,6 @@
 from django.conf import settings
-from pusher import Pusher
+
+from drf_model_pusher.proxies import PusherProxy
 
 
 def send_pusher_event(
@@ -13,7 +14,7 @@ def send_pusher_event(
     except AttributeError:
         pusher_cluster = "mt1"
 
-    pusher = Pusher(
+    pusher = PusherProxy(
         app_id=settings.PUSHER_APP_ID,
         key=settings.PUSHER_KEY,
         secret=settings.PUSHER_SECRET,


### PR DESCRIPTION
Implements a `PusherProxy` class that can be used whenever to interact with the underlying `Pusher` client. Allows easier mocking and extended logic. Also includes an implementation for a `DRF_MODEL_PUSHER_DISABLED` setting which defaults to `False` and allows the user to disabled calls to `Pusher.trigger` for CI purposes or otherwise. Docs included for the new setting.

Fixes #15 