### PR TITLE
Feature/presence channels

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,7 +6,7 @@ name = "pypi"
 [packages]
 Django = "==2.0"
 djangorestframework = "*"
-pusher = "*"
+pusher = "==2.1.4"
 
 [dev-packages]
 pytest = "*"

--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@ The PusherBackend.push_change method accepts an `ignore` boolean keyword argumen
 
 - `DRF_MODEL_PUSHER_BACKENDS_FILE` (default: `pusher_backends.py`) - The file in your applications to import PusherBackends.
 - `DRF_MODEL_PUSHER_DISABLED` (default: `False`) - Determines whether or not to trigger Pusher events.
-- `DRF_MODEL_PUSHER_OPTIMISE_PRESENCE_EVENTS` (default: `False`) - Determines whether or not to trigger Pusher events in [presence channels](https://pusher.com/docs/channels/using_channels/presence-channels) when no users are subscribed.
 
 ## Common Issues
 ### Unregistered Backends

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ The PusherBackend.push_change method accepts an `ignore` boolean keyword argumen
 
 - `DRF_MODEL_PUSHER_BACKENDS_FILE` (default: `pusher_backends.py`) - The file in your applications to import PusherBackends.
 - `DRF_MODEL_PUSHER_DISABLED` (default: `False`) - Determines whether or not to trigger Pusher events.
+- `DRF_MODEL_PUSHER_OPTIMISE_PRESENCE_EVENTS` (default: `False`) - Determines whether or not to trigger Pusher events in [presence channels](https://pusher.com/docs/channels/using_channels/presence-channels) when no users are subscribed.
 
 ## Common Issues
 ### Unregistered Backends

--- a/drf_model_pusher/backends.py
+++ b/drf_model_pusher/backends.py
@@ -127,6 +127,19 @@ class PrivatePusherBackend(PusherBackend):
         return "private-{channel}".format(channel=channel)
 
 
+class PresencePusherBackend(PusherBackend):
+    """PresencePusherBackend is the base class for implementing serializers
+    with Pusher and prefixing the channel with `presence-`."""
+
+    class Meta:
+        abstract = True
+
+    def get_channel(self, instance=None):
+        """Return the channel prefixed with `presence-`"""
+        channel = super().get_channel(instance=instance)
+        return "presence-{channel}".format(channel=channel)
+
+
 def get_models_pusher_backends(model):
     """Return the pusher backends registered for a model"""
     return pusher_backend_registry.get(model.__name__.lower(), [])

--- a/drf_model_pusher/backends.py
+++ b/drf_model_pusher/backends.py
@@ -135,36 +135,6 @@ class PresencePusherBackend(PusherBackend):
         channel = super().get_channel(instance=instance)
         return "presence-{channel}".format(channel=channel)
 
-    def push_change(self, event, instance=None, pre_destroy=False, ignore=True):
-        if not PresencePusherBackend.should_send(channels=self.get_channels(instance)):
-            return
-
-        return super(PresencePusherBackend, self).push_change(
-            event,
-            instance=instance,
-            pre_destroy=pre_destroy,
-            ignore=ignore
-        )
-
-    @classmethod
-    def should_send(cls, channels=list(), ):
-        if getattr(settings, "DRF_MODEL_PUSHER_OPTIMISE_PRESENCE_EVENTS", False):
-            pusher = cls.provider_class()
-            pusher.configure()
-
-            # For each channel, validate that there is any users in the channel
-            # if there is users in any of the target channels we send the event
-            abort = True
-            for channel in channels:
-                response = pusher._pusher.channel_info(channel, ["user_count"])
-
-                if response["user_count"] > 0:
-                    abort = False
-
-            if abort:
-                return False
-        return True
-
 
 def get_models_pusher_backends(model):
     """Return the pusher backends registered for a model"""

--- a/drf_model_pusher/providers.py
+++ b/drf_model_pusher/providers.py
@@ -30,7 +30,7 @@ class PusherProvider(object):
 
     def trigger(self, channels, event_name, data, socket_id=None):
         if not isinstance(channels, list):
-            raise TypeError(f"channels must be a list, received {type(channels)}")
+            raise TypeError("channels must be a list, received {0}".format(str(type(channels))))
 
         if self._disabled:
             return

--- a/drf_model_pusher/providers.py
+++ b/drf_model_pusher/providers.py
@@ -32,6 +32,9 @@ class PusherProvider(object):
         if self._disabled:
             return
 
+        if self._pusher is None:
+            self.configure()
+
         self._pusher.trigger(channels, event_name, data, socket_id)
 
 

--- a/drf_model_pusher/providers.py
+++ b/drf_model_pusher/providers.py
@@ -29,13 +29,25 @@ class PusherProvider(object):
         )
 
     def trigger(self, channels, event_name, data, socket_id=None):
+        if not isinstance(channels, list):
+            raise TypeError(f"channels must be a list, received {type(channels)}")
+
         if self._disabled:
             return
 
         if self._pusher is None:
             self.configure()
 
-        self._pusher.trigger(channels, event_name, data, socket_id)
+        # If there are any presence channels, respect the optimisation setting
+        presence_channels = list(filter(lambda c: c.startswith("presence-"), channels))
+        channels = list(filter(lambda c: not c.startswith("presence-"), channels))
+
+        if channels:
+            self._pusher.trigger(channels, event_name, data, socket_id)
+
+        from drf_model_pusher.backends import PresencePusherBackend
+        if presence_channels and PresencePusherBackend.should_send(channels=presence_channels):
+            self._pusher.trigger(presence_channels, event_name, data, socket_id)
 
 
 class AblyProvider(object):

--- a/drf_model_pusher/providers.py
+++ b/drf_model_pusher/providers.py
@@ -38,16 +38,7 @@ class PusherProvider(object):
         if self._pusher is None:
             self.configure()
 
-        # If there are any presence channels, respect the optimisation setting
-        presence_channels = list(filter(lambda c: c.startswith("presence-"), channels))
-        channels = list(filter(lambda c: not c.startswith("presence-"), channels))
-
-        if channels:
-            self._pusher.trigger(channels, event_name, data, socket_id)
-
-        from drf_model_pusher.backends import PresencePusherBackend
-        if presence_channels and PresencePusherBackend.should_send(channels=presence_channels):
-            self._pusher.trigger(presence_channels, event_name, data, socket_id)
+        self._pusher.trigger(channels, event_name, data, socket_id)
 
 
 class AblyProvider(object):

--- a/example/models.py
+++ b/example/models.py
@@ -1,5 +1,13 @@
 from django.db import models
 
 
-class MyModel(models.Model):
+class MyPublicModel(models.Model):
+    name = models.CharField(max_length=32)
+
+
+class MyPrivateModel(models.Model):
+    name = models.CharField(max_length=32)
+
+
+class MyPresenceModel(models.Model):
     name = models.CharField(max_length=32)

--- a/example/pusher_backends.py
+++ b/example/pusher_backends.py
@@ -1,6 +1,14 @@
-from drf_model_pusher.backends import PusherBackend
-from example.serializers import MyModelSerializer
+from drf_model_pusher.backends import PusherBackend, PrivatePusherBackend, PresencePusherBackend
+from example.serializers import MyPublicModelSerializer, MyPrivateModelSerializer, MyPresenceModelSerializer
 
 
-class MyModelPusherBackend(PusherBackend):
-    serializer_class = MyModelSerializer
+class MyPublicModelPusherBackend(PusherBackend):
+    serializer_class = MyPublicModelSerializer
+
+
+class MyPrivateModelBackend(PrivatePusherBackend):
+    serializer_class = MyPrivateModelSerializer
+
+
+class MyPresenceModelBackend(PresencePusherBackend):
+    serializer_class = MyPresenceModelSerializer

--- a/example/serializers.py
+++ b/example/serializers.py
@@ -1,9 +1,21 @@
 from rest_framework import serializers
 
-from example.models import MyModel
+from example.models import MyPublicModel, MyPrivateModel, MyPresenceModel
 
 
-class MyModelSerializer(serializers.ModelSerializer):
+class MyPublicModelSerializer(serializers.ModelSerializer):
     class Meta:
-        model = MyModel
+        model = MyPublicModel
+        fields = ("name",)
+
+
+class MyPrivateModelSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = MyPrivateModel
+        fields = ("name",)
+
+
+class MyPresenceModelSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = MyPresenceModel
         fields = ("name",)

--- a/example/views.py
+++ b/example/views.py
@@ -1,13 +1,30 @@
 from rest_framework import viewsets
 
 from drf_model_pusher.views import ModelPusherViewMixin
-from example.models import MyModel
-from example.serializers import MyModelSerializer
+from example.models import MyPublicModel, MyPrivateModel, MyPresenceModel
+from example.serializers import MyPublicModelSerializer, MyPrivateModelSerializer, \
+    MyPresenceModelSerializer
 
 
-class MyModelViewSet(ModelPusherViewMixin, viewsets.ModelViewSet):
-    queryset = MyModel.objects.all()
-    serializer_class = MyModelSerializer
+class MyPublicModelViewSet(ModelPusherViewMixin, viewsets.ModelViewSet):
+    queryset = MyPublicModel.objects.all()
+    serializer_class = MyPublicModelSerializer
 
     def get_pusher_channels(self):
         return ["channel"]
+
+
+class MyPrivateModelViewSet(ModelPusherViewMixin, viewsets.ModelViewSet):
+    queryset = MyPrivateModel.objects.all()
+    serializer_class = MyPrivateModelSerializer
+
+    def get_pusher_channels(self):
+        return ["private-channel"]
+
+
+class MyPresenceModelViewSet(ModelPusherViewMixin, viewsets.ModelViewSet):
+    queryset = MyPresenceModel.objects.all()
+    serializer_class = MyPresenceModelSerializer
+
+    def get_pusher_channels(self):
+        return ["presence-channel"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ more-itertools==4.2.0
 ndg-httpsclient==0.5.0
 packaging==17.1
 pluggy==0.6.0
-pusher==2.0.1
+pusher==2.1.4
 py==1.5.4
 pyasn1==0.4.3
 pycparser==2.18

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -4,13 +4,13 @@ from unittest.mock import Mock
 from pytest import mark
 from rest_framework.test import APIRequestFactory
 
-from example.models import MyModel
-from example.serializers import MyModelSerializer
-from example.views import MyModelViewSet
+from example.models import MyPublicModel, MyPrivateModel, MyPresenceModel
+from example.serializers import MyPublicModelSerializer, MyPrivateModelSerializer, MyPresenceModelSerializer
+from example.views import MyPublicModelViewSet, MyPrivateModelViewSet, MyPresenceModelViewSet
 
 
 @mark.django_db
-class TestModelPusherViewMixin(TestCase):
+class TestModelPusherViewMixinPublicChannels(TestCase):
     """Integration tests between models, serializers, pusher backends, and views."""
 
     @mock.patch("pusher.Pusher.trigger")
@@ -19,50 +19,168 @@ class TestModelPusherViewMixin(TestCase):
         request_factory = APIRequestFactory()
         create_request = request_factory.post(path="/mymodels/", data={"name": "Henry"})
 
-        view = MyModelViewSet.as_view({"post": "create"})
+        view = MyPublicModelViewSet.as_view({"post": "create"})
         response = view(create_request)
-        instance = MyModel.objects.last()
+        instance = MyPublicModel.objects.last()
 
         self.assertEqual(response.status_code, 201, response.data)
 
         trigger.assert_called_once_with(
-            ["channel"], "mymodel.create", MyModelSerializer(instance=instance).data, None
+            ["channel"], "mypublicmodel.create", MyPublicModelSerializer(instance=instance).data, None
         )
 
     @mock.patch("pusher.Pusher.trigger")
     def test_updates_are_pushed(self, trigger: Mock):
-        instance = MyModel.objects.create(name="Julie")
+        instance = MyPublicModel.objects.create(name="Julie")
 
         request_factory = APIRequestFactory()
         partial_update_request = request_factory.patch(
             path="/mymodels/123/", data={"name": "Michelle"}
         )
 
-        view = MyModelViewSet.as_view({"patch": "partial_update"})
+        view = MyPublicModelViewSet.as_view({"patch": "partial_update"})
         response = view(partial_update_request, pk=instance.pk)
-        instance = MyModel.objects.last()
+        instance = MyPublicModel.objects.last()
 
         self.assertEqual(response.status_code, 200, response.data)
         self.assertEqual(instance.name, "Michelle")
 
         trigger.assert_called_once_with(
-            ["channel"], "mymodel.update", MyModelSerializer(instance=instance).data, None
+            ["channel"], "mypublicmodel.update", MyPublicModelSerializer(instance=instance).data, None
         )
 
     @mock.patch("pusher.Pusher.trigger")
     def test_deletions_are_pushed(self, trigger: Mock):
-        instance = MyModel.objects.create(name="Henry")
+        instance = MyPublicModel.objects.create(name="Henry")
 
         request_factory = APIRequestFactory()
         delete_request = request_factory.delete(path="/mymodels/1/")
 
-        view = MyModelViewSet.as_view({"delete": "destroy"})
+        view = MyPublicModelViewSet.as_view({"delete": "destroy"})
         response = view(delete_request, pk=instance.pk)
 
         self.assertEqual(response.status_code, 204, response.data)
-        with self.assertRaises(MyModel.DoesNotExist):
-            instance = MyModel.objects.get(pk=instance.pk)
+        with self.assertRaises(MyPublicModel.DoesNotExist):
+            instance = MyPublicModel.objects.get(pk=instance.pk)
 
         trigger.assert_called_once_with(
-            ["channel"], "mymodel.delete", MyModelSerializer(instance=instance).data, None
+            ["channel"], "mypublicmodel.delete", MyPublicModelSerializer(instance=instance).data, None
+        )
+
+
+@mark.django_db
+class TestModelPusherViewMixinPrivateChannels(TestCase):
+    """Integration tests between models, serializers, pusher backends, and views."""
+
+    @mock.patch("pusher.Pusher.trigger")
+    def test_creations_are_pushed(self, trigger: Mock):
+
+        request_factory = APIRequestFactory()
+        create_request = request_factory.post(path="/mymodels/", data={"name": "Henry"})
+
+        view = MyPrivateModelViewSet.as_view({"post": "create"})
+        response = view(create_request)
+        instance = MyPrivateModel.objects.last()
+
+        self.assertEqual(response.status_code, 201, response.data)
+
+        trigger.assert_called_once_with(
+            ["private-channel"], "myprivatemodel.create", MyPrivateModelSerializer(instance=instance).data, None
+        )
+
+    @mock.patch("pusher.Pusher.trigger")
+    def test_updates_are_pushed(self, trigger: Mock):
+        instance = MyPrivateModel.objects.create(name="Julie")
+
+        request_factory = APIRequestFactory()
+        partial_update_request = request_factory.patch(
+            path="/mymodels/123/", data={"name": "Michelle"}
+        )
+
+        view = MyPrivateModelViewSet.as_view({"patch": "partial_update"})
+        response = view(partial_update_request, pk=instance.pk)
+        instance = MyPrivateModel.objects.last()
+
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(instance.name, "Michelle")
+
+        trigger.assert_called_once_with(
+            ["private-channel"], "myprivatemodel.update", MyPrivateModelSerializer(instance=instance).data, None
+        )
+
+    @mock.patch("pusher.Pusher.trigger")
+    def test_deletions_are_pushed(self, trigger: Mock):
+        instance = MyPrivateModel.objects.create(name="Henry")
+
+        request_factory = APIRequestFactory()
+        delete_request = request_factory.delete(path="/mymodels/1/")
+
+        view = MyPrivateModelViewSet.as_view({"delete": "destroy"})
+        response = view(delete_request, pk=instance.pk)
+
+        self.assertEqual(response.status_code, 204, response.data)
+        with self.assertRaises(MyPrivateModel.DoesNotExist):
+            instance = MyPrivateModel.objects.get(pk=instance.pk)
+
+        trigger.assert_called_once_with(
+            ["private-channel"], "myprivatemodel.delete", MyPrivateModelSerializer(instance=instance).data, None
+        )
+
+
+@mark.django_db
+class TestModelPusherViewMixinPresenceChannels(TestCase):
+    """Integration tests between models, serializers, pusher backends, and views."""
+
+    @mock.patch("pusher.Pusher.trigger")
+    def test_creations_are_pushed(self, trigger: Mock):
+
+        request_factory = APIRequestFactory()
+        create_request = request_factory.post(path="/mymodels/", data={"name": "Henry"})
+
+        view = MyPresenceModelViewSet.as_view({"post": "create"})
+        response = view(create_request)
+        instance = MyPresenceModel.objects.last()
+
+        self.assertEqual(response.status_code, 201, response.data)
+
+        trigger.assert_called_once_with(
+            ["presence-channel"], "mypresencemodel.create", MyPresenceModelSerializer(instance=instance).data, None
+        )
+
+    @mock.patch("pusher.Pusher.trigger")
+    def test_updates_are_pushed(self, trigger: Mock):
+        instance = MyPresenceModel.objects.create(name="Julie")
+
+        request_factory = APIRequestFactory()
+        partial_update_request = request_factory.patch(
+            path="/mymodels/123/", data={"name": "Michelle"}
+        )
+
+        view = MyPresenceModelViewSet.as_view({"patch": "partial_update"})
+        response = view(partial_update_request, pk=instance.pk)
+        instance = MyPresenceModel.objects.last()
+
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(instance.name, "Michelle")
+
+        trigger.assert_called_once_with(
+            ["presence-channel"], "mypresencemodel.update", MyPresenceModelSerializer(instance=instance).data, None
+        )
+
+    @mock.patch("pusher.Pusher.trigger")
+    def test_deletions_are_pushed(self, trigger: Mock):
+        instance = MyPresenceModel.objects.create(name="Henry")
+
+        request_factory = APIRequestFactory()
+        delete_request = request_factory.delete(path="/mymodels/1/")
+
+        view = MyPresenceModelViewSet.as_view({"delete": "destroy"})
+        response = view(delete_request, pk=instance.pk)
+
+        self.assertEqual(response.status_code, 204, response.data)
+        with self.assertRaises(MyPresenceModel.DoesNotExist):
+            instance = MyPresenceModel.objects.get(pk=instance.pk)
+
+        trigger.assert_called_once_with(
+            ["presence-channel"], "mypresencemodel.delete", MyPresenceModelSerializer(instance=instance).data, None
         )

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -185,37 +185,3 @@ class TestModelPusherViewMixinPresenceChannels(TestCase):
         trigger.assert_called_once_with(
             ["presence-channel"], "mypresencemodel.delete", MyPresenceModelSerializer(instance=instance).data, None
         )
-
-    @mock.patch("pusher.Pusher.trigger")
-    @mock.patch("pusher.Pusher.channel_info")
-    @override_settings(DRF_MODEL_PUSHER_OPTIMISE_PRESENCE_EVENTS=True)
-    def test_creations_are_pushed_when_optimised_events_are_on(self, channel_info: Mock, trigger: Mock):
-        request_factory = APIRequestFactory()
-        create_request = request_factory.post(path="/mymodels/", data={"name": "Henry"})
-
-        channel_info.return_value = {"user_count": 1}
-
-        view = MyPresenceModelViewSet.as_view({"post": "create"})
-        response = view(create_request)
-        instance = MyPresenceModel.objects.last()
-
-        self.assertEqual(response.status_code, 201, response.data)
-
-        trigger.assert_called_once_with(
-            ["presence-channel"], "mypresencemodel.create", MyPresenceModelSerializer(instance=instance).data, None
-        )
-
-    @mock.patch("pusher.Pusher.trigger")
-    @mock.patch("pusher.Pusher.channel_info")
-    @override_settings(DRF_MODEL_PUSHER_OPTIMISE_PRESENCE_EVENTS=True)
-    def test_creations_are_not_pushed_when_optimised_events_are_on(self, channel_info: Mock, trigger: Mock):
-        request_factory = APIRequestFactory()
-        create_request = request_factory.post(path="/mymodels/", data={"name": "Henry"})
-
-        channel_info.return_value = {"user_count": 0}
-
-        view = MyPresenceModelViewSet.as_view({"post": "create"})
-        response = view(create_request)
-
-        self.assertEqual(response.status_code, 201, response.data)
-        trigger.assert_not_called()


### PR DESCRIPTION
Fixes #33 

- Adds `PresencePusherBackend` to implement presence channels.
- ~Implements new `DRF_MODEL_PUSHER_OPTIMISE_PRESENCE_EVENTS` setting to stop events triggering when no one is in a presence channel.~
- ~Documents `DRF_MODEL_PUSHER_OPTIMISE_PRESENCE_EVENTS` in README.~
- Adds tests for private and presence channels.