### PR TITLE
Feature/channel cache

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,7 +6,7 @@ name = "pypi"
 [packages]
 Django = "==2.0"
 djangorestframework = "*"
-pusher = "*"
+pusher = "==2.1.4"
 
 [dev-packages]
 pytest = "*"

--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@ The PusherBackend.push_change method accepts an `ignore` boolean keyword argumen
 
 - `DRF_MODEL_PUSHER_BACKENDS_FILE` (default: `pusher_backends.py`) - The file in your applications to import PusherBackends.
 - `DRF_MODEL_PUSHER_DISABLED` (default: `False`) - Determines whether or not to trigger Pusher events.
-- `DRF_MODEL_PUSHER_OPTIMISE_PRESENCE_EVENTS` (default: `False`) - Determines whether or not to trigger Pusher events in [presence channels](https://pusher.com/docs/channels/using_channels/presence-channels) when no users are subscribed.
 
 ## Common Issues
 ### Unregistered Backends

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ The PusherBackend.push_change method accepts an `ignore` boolean keyword argumen
 
 - `DRF_MODEL_PUSHER_BACKENDS_FILE` (default: `pusher_backends.py`) - The file in your applications to import PusherBackends.
 - `DRF_MODEL_PUSHER_DISABLED` (default: `False`) - Determines whether or not to trigger Pusher events.
+- `DRF_MODEL_PUSHER_OPTIMISE_PRESENCE_EVENTS` (default: `False`) - Determines whether or not to trigger Pusher events in [presence channels](https://pusher.com/docs/channels/using_channels/presence-channels) when no users are subscribed.
 
 ## Common Issues
 ### Unregistered Backends

--- a/drf_model_pusher/authentication.py
+++ b/drf_model_pusher/authentication.py
@@ -1,3 +1,5 @@
+import json
+
 from rest_framework.authentication import BaseAuthentication
 from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.request import Request
@@ -16,7 +18,7 @@ class PusherWebhookAuthentication(BaseAuthentication):
         validated_data = PusherProvider().client.validate_webhook(
             key=request.META.get("HTTP_X_PUSHER_KEY"),
             signature=request.META.get("HTTP_X_PUSHER_SIGNATURE"),
-            body=str(request.data)
+            body=json.dumps(request.data, separators=(',', ':'))
         )
 
         if validated_data is None:

--- a/drf_model_pusher/authentication.py
+++ b/drf_model_pusher/authentication.py
@@ -1,0 +1,24 @@
+from rest_framework.authentication import BaseAuthentication
+from rest_framework.exceptions import AuthenticationFailed
+
+from drf_model_pusher.providers import PusherProvider
+
+
+class PusherWebhookAuthentication(BaseAuthentication):
+    def authenticate(self, request):
+        """
+        Makes sure to validate auth headers with Pusher
+        https://pusher.com/docs/channels/server_api/webhooks#authentication
+        :param request:
+        :return:
+        """
+        validated_data = PusherProvider().client.validate_webhook(
+            key=request.META.get("HTTP_X_PUSHER_KEY"),
+            signature=request.META.get("HTTP_X_PUSHER_SIGNATURE"),
+            body=request.data
+        )
+
+        if validated_data is None:
+            raise AuthenticationFailed()
+
+        return (None, None,)

--- a/drf_model_pusher/authentication.py
+++ b/drf_model_pusher/authentication.py
@@ -1,11 +1,12 @@
 from rest_framework.authentication import BaseAuthentication
 from rest_framework.exceptions import AuthenticationFailed
+from rest_framework.request import Request
 
 from drf_model_pusher.providers import PusherProvider
 
 
 class PusherWebhookAuthentication(BaseAuthentication):
-    def authenticate(self, request):
+    def authenticate(self, request: Request):
         """
         Makes sure to validate auth headers with Pusher
         https://pusher.com/docs/channels/server_api/webhooks#authentication
@@ -15,7 +16,7 @@ class PusherWebhookAuthentication(BaseAuthentication):
         validated_data = PusherProvider().client.validate_webhook(
             key=request.META.get("HTTP_X_PUSHER_KEY"),
             signature=request.META.get("HTTP_X_PUSHER_SIGNATURE"),
-            body=request.data
+            body=request._request.body
         )
 
         if validated_data is None:

--- a/drf_model_pusher/authentication.py
+++ b/drf_model_pusher/authentication.py
@@ -16,7 +16,7 @@ class PusherWebhookAuthentication(BaseAuthentication):
         validated_data = PusherProvider().client.validate_webhook(
             key=request.META.get("HTTP_X_PUSHER_KEY"),
             signature=request.META.get("HTTP_X_PUSHER_SIGNATURE"),
-            body=request._request.body
+            body=str(request.data)
         )
 
         if validated_data is None:

--- a/drf_model_pusher/backends.py
+++ b/drf_model_pusher/backends.py
@@ -127,6 +127,19 @@ class PrivatePusherBackend(PusherBackend):
         return "private-{channel}".format(channel=channel)
 
 
+class PresencePusherBackend(PusherBackend):
+    """PresencePusherBackend is the base class for implementing serializers
+    with Pusher and prefixing the channel with `presence-`."""
+
+    class Meta:
+        abstract = True
+
+    def get_channel(self, instance=None):
+        """Return the channel prefixed with `presence-`"""
+        channel = super().get_channel(instance=instance)
+        return "presence-{channel}".format(channel=channel)
+
+
 def get_models_pusher_backends(model):
     """Return the pusher backends registered for a model"""
     return pusher_backend_registry.get(model.__name__.lower(), [])

--- a/drf_model_pusher/backends.py
+++ b/drf_model_pusher/backends.py
@@ -135,36 +135,6 @@ class PresencePusherBackend(PusherBackend):
         channel = super().get_channel(instance=instance)
         return "presence-{channel}".format(channel=channel)
 
-    def push_change(self, event, instance=None, pre_destroy=False, ignore=True):
-        if not PresencePusherBackend.should_send(channels=self.get_channels(instance)):
-            return
-
-        return super(PresencePusherBackend, self).push_change(
-            event,
-            instance=instance,
-            pre_destroy=pre_destroy,
-            ignore=ignore
-        )
-
-    @classmethod
-    def should_send(cls, channels=list(), ):
-        if getattr(settings, "DRF_MODEL_PUSHER_OPTIMISE_PRESENCE_EVENTS", False):
-            pusher = cls.provider_class()
-            pusher.configure()
-
-            # For each channel, validate that there is any users in the channel
-            # if there is users in any of the target channels we send the event
-            abort = True
-            for channel in channels:
-                response = pusher._pusher.channel_info(channel, ["user_count"])
-
-                if response["user_count"] > 0:
-                    abort = False
-
-            if abort:
-                return False
-        return True
-
 
 def get_models_pusher_backends(model):
     """Return the pusher backends registered for a model"""

--- a/drf_model_pusher/providers.py
+++ b/drf_model_pusher/providers.py
@@ -30,7 +30,7 @@ class PusherProvider(object):
 
     def trigger(self, channels, event_name, data, socket_id=None):
         if not isinstance(channels, list):
-            raise TypeError(f"channels must be a list, received {type(channels)}")
+            raise TypeError("channels must be a list, received {0}".format(str(type(channels))))
 
         if self._disabled:
             return

--- a/drf_model_pusher/providers.py
+++ b/drf_model_pusher/providers.py
@@ -35,10 +35,14 @@ class PusherProvider(object):
         if self._disabled:
             return
 
+        self.client.trigger(channels, event_name, data, socket_id)
+
+    @property
+    def client(self):
         if self._pusher is None:
             self.configure()
 
-        self._pusher.trigger(channels, event_name, data, socket_id)
+        return self._pusher
 
 
 class AblyProvider(object):

--- a/drf_model_pusher/providers.py
+++ b/drf_model_pusher/providers.py
@@ -32,6 +32,9 @@ class PusherProvider(object):
         if self._disabled:
             return
 
+        if self._pusher is None:
+            self.configure()
+
         self._pusher.trigger(channels, event_name, data, socket_id)
 
 

--- a/drf_model_pusher/providers.py
+++ b/drf_model_pusher/providers.py
@@ -29,13 +29,25 @@ class PusherProvider(object):
         )
 
     def trigger(self, channels, event_name, data, socket_id=None):
+        if not isinstance(channels, list):
+            raise TypeError(f"channels must be a list, received {type(channels)}")
+
         if self._disabled:
             return
 
         if self._pusher is None:
             self.configure()
 
-        self._pusher.trigger(channels, event_name, data, socket_id)
+        # If there are any presence channels, respect the optimisation setting
+        presence_channels = list(filter(lambda c: c.startswith("presence-"), channels))
+        channels = list(filter(lambda c: not c.startswith("presence-"), channels))
+
+        if channels:
+            self._pusher.trigger(channels, event_name, data, socket_id)
+
+        from drf_model_pusher.backends import PresencePusherBackend
+        if presence_channels and PresencePusherBackend.should_send(channels=presence_channels):
+            self._pusher.trigger(presence_channels, event_name, data, socket_id)
 
 
 class AblyProvider(object):

--- a/drf_model_pusher/providers.py
+++ b/drf_model_pusher/providers.py
@@ -1,5 +1,6 @@
 
 from django.conf import settings
+from django.core.cache import cache
 from pusher import Pusher
 
 
@@ -35,14 +36,45 @@ class PusherProvider(object):
         if self._disabled:
             return
 
-        self.client.trigger(channels, event_name, data, socket_id)
+        valid_channels = channels
+
+        # Only send events to channels that are occupied
+        if getattr(settings, "DRF_MODEL_PUSHER_WEBHOOK_OPTIMISATION_ENABLED", False):
+            valid_channels = []
+            for channel in channels:
+                cache_key = "drf-model-pusher:occupied:{}".format(channel)
+                occupied = cache.get(cache_key)
+
+                if occupied is None:
+                    self._sync_cache()
+                    occupied = cache.get(cache_key)
+
+                if occupied is False:
+                    continue
+
+                if occupied is True:
+                    valid_channels.append(channel)
+
+        if valid_channels:
+            self.client.trigger(valid_channels, event_name, data, socket_id)
 
     @property
-    def client(self):
+    def client(self) -> Pusher:
         if self._pusher is None:
             self.configure()
 
         return self._pusher
+
+    def _sync_cache(self):
+        """
+        Fetches channel existence state from Pusher and stores the results in the cache
+        :return:
+        """
+        response = self.client.channels_info()
+        occupied_channels = response.get("channels", {}).keys()
+
+        for channel in occupied_channels:
+            cache.set("drf-model-pusher:occupied:{}".format(channel), True)
 
 
 class AblyProvider(object):

--- a/drf_model_pusher/providers.py
+++ b/drf_model_pusher/providers.py
@@ -38,16 +38,7 @@ class PusherProvider(object):
         if self._pusher is None:
             self.configure()
 
-        # If there are any presence channels, respect the optimisation setting
-        presence_channels = list(filter(lambda c: c.startswith("presence-"), channels))
-        channels = list(filter(lambda c: not c.startswith("presence-"), channels))
-
-        if channels:
-            self._pusher.trigger(channels, event_name, data, socket_id)
-
-        from drf_model_pusher.backends import PresencePusherBackend
-        if presence_channels and PresencePusherBackend.should_send(channels=presence_channels):
-            self._pusher.trigger(presence_channels, event_name, data, socket_id)
+        self._pusher.trigger(channels, event_name, data, socket_id)
 
 
 class AblyProvider(object):

--- a/drf_model_pusher/serializers.py
+++ b/drf_model_pusher/serializers.py
@@ -34,14 +34,14 @@ class ChannelExistenceSerializer(PusherWebhookSerializer):
 
     def create(self, validated_data):
         for event in validated_data.get("events", []):
-            # Channel is occupied, add it to the cache
+            cache_key = "drf-model-pusher:occupied:{}".format(event["channel"])
+
+            # Channel is occupied, set it to True
             if event["name"] == "channel_occupied":
-                cache_key = "drf-model-pusher:occupied:{}".format(event["channel"])
                 cache.set(cache_key, True)
 
-            # Channel has been vacated, remove it from the cache
+            # Channel has been vacated, set it to False
             if event["name"] == "channel_vacated":
-                cache_key = "drf-model-pusher:occupied:{}".format(event["channel"])
-                cache.delete(cache_key)
+                cache.set(cache_key, False)
 
         return validated_data

--- a/drf_model_pusher/serializers.py
+++ b/drf_model_pusher/serializers.py
@@ -1,0 +1,35 @@
+from rest_framework import serializers
+
+
+class PusherWebhookSerializer(serializers.Serializer):
+    """
+    Generic serializer to be used as the base of any Pusher webhook, represents the standard webhook format
+    https://pusher.com/docs/channels/server_api/webhooks#webhook-format
+    """
+    time_ms = serializers.IntegerField()
+
+
+class EventSerializer(serializers.Serializer):
+    """
+    Generic serializer to be used as the base of any Pusher webhook event
+    """
+    name = serializers.CharField()
+
+
+class ChannelExistenceEventSerializer(EventSerializer):
+    """
+    Pusher webhook event serializer representing channel existence events
+    https://pusher.com/docs/channels/server_api/webhooks#channel-existence-events
+    """
+    channel = serializers.CharField()
+
+
+class ChannelExistenceSerializer(PusherWebhookSerializer):
+    """
+    Pusher webhook serializer representing a channel existence webhook
+    https://pusher.com/docs/channels/server_api/webhooks#channel-existence-events
+    """
+    events = ChannelExistenceEventSerializer(many=True)
+
+    def create(self, validated_data):
+        return validated_data

--- a/drf_model_pusher/views.py
+++ b/drf_model_pusher/views.py
@@ -1,5 +1,9 @@
+from rest_framework.generics import CreateAPIView
+
+from drf_model_pusher.authentication import PusherWebhookAuthentication
 from drf_model_pusher.backends import get_models_pusher_backends
 from drf_model_pusher.exceptions import ModelPusherException
+from drf_model_pusher.serializers import ChannelExistenceSerializer
 from drf_model_pusher.signals import view_post_save
 
 
@@ -80,3 +84,8 @@ class ModelPusherViewMixin(object):
             event_name=event_name,
             data=data,
         )
+
+
+class ChannelExistenceWebhook(CreateAPIView):
+    authentication_classes = [PusherWebhookAuthentication]
+    serializer_class = ChannelExistenceSerializer

--- a/example/models.py
+++ b/example/models.py
@@ -1,5 +1,13 @@
 from django.db import models
 
 
-class MyModel(models.Model):
+class MyPublicModel(models.Model):
+    name = models.CharField(max_length=32)
+
+
+class MyPrivateModel(models.Model):
+    name = models.CharField(max_length=32)
+
+
+class MyPresenceModel(models.Model):
     name = models.CharField(max_length=32)

--- a/example/pusher_backends.py
+++ b/example/pusher_backends.py
@@ -1,6 +1,14 @@
-from drf_model_pusher.backends import PusherBackend
-from example.serializers import MyModelSerializer
+from drf_model_pusher.backends import PusherBackend, PrivatePusherBackend, PresencePusherBackend
+from example.serializers import MyPublicModelSerializer, MyPrivateModelSerializer, MyPresenceModelSerializer
 
 
-class MyModelPusherBackend(PusherBackend):
-    serializer_class = MyModelSerializer
+class MyPublicModelPusherBackend(PusherBackend):
+    serializer_class = MyPublicModelSerializer
+
+
+class MyPrivateModelBackend(PrivatePusherBackend):
+    serializer_class = MyPrivateModelSerializer
+
+
+class MyPresenceModelBackend(PresencePusherBackend):
+    serializer_class = MyPresenceModelSerializer

--- a/example/serializers.py
+++ b/example/serializers.py
@@ -1,9 +1,21 @@
 from rest_framework import serializers
 
-from example.models import MyModel
+from example.models import MyPublicModel, MyPrivateModel, MyPresenceModel
 
 
-class MyModelSerializer(serializers.ModelSerializer):
+class MyPublicModelSerializer(serializers.ModelSerializer):
     class Meta:
-        model = MyModel
+        model = MyPublicModel
+        fields = ("name",)
+
+
+class MyPrivateModelSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = MyPrivateModel
+        fields = ("name",)
+
+
+class MyPresenceModelSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = MyPresenceModel
         fields = ("name",)

--- a/example/views.py
+++ b/example/views.py
@@ -1,13 +1,30 @@
 from rest_framework import viewsets
 
 from drf_model_pusher.views import ModelPusherViewMixin
-from example.models import MyModel
-from example.serializers import MyModelSerializer
+from example.models import MyPublicModel, MyPrivateModel, MyPresenceModel
+from example.serializers import MyPublicModelSerializer, MyPrivateModelSerializer, \
+    MyPresenceModelSerializer
 
 
-class MyModelViewSet(ModelPusherViewMixin, viewsets.ModelViewSet):
-    queryset = MyModel.objects.all()
-    serializer_class = MyModelSerializer
+class MyPublicModelViewSet(ModelPusherViewMixin, viewsets.ModelViewSet):
+    queryset = MyPublicModel.objects.all()
+    serializer_class = MyPublicModelSerializer
 
     def get_pusher_channels(self):
         return ["channel"]
+
+
+class MyPrivateModelViewSet(ModelPusherViewMixin, viewsets.ModelViewSet):
+    queryset = MyPrivateModel.objects.all()
+    serializer_class = MyPrivateModelSerializer
+
+    def get_pusher_channels(self):
+        return ["private-channel"]
+
+
+class MyPresenceModelViewSet(ModelPusherViewMixin, viewsets.ModelViewSet):
+    queryset = MyPresenceModel.objects.all()
+    serializer_class = MyPresenceModelSerializer
+
+    def get_pusher_channels(self):
+        return ["presence-channel"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ more-itertools==4.2.0
 ndg-httpsclient==0.5.0
 packaging==17.1
 pluggy==0.6.0
-pusher==2.0.1
+pusher==2.1.4
 py==1.5.4
 pyasn1==0.4.3
 pycparser==2.18

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,0 +1,47 @@
+from unittest import TestCase, mock
+from unittest.mock import Mock
+
+from django.core.cache import cache
+from django.test import override_settings
+
+from drf_model_pusher.providers import PusherProvider
+
+
+class TestPusherProvider(TestCase):
+    def tearDown(self):
+        cache.clear()
+
+    @mock.patch("pusher.Pusher.trigger")
+    def test_trigger_calls_pusher_trigger(self, trigger: Mock):
+        provider = PusherProvider()
+        provider.trigger(["my-channel"], "myevent", {"foo": "bar"})
+        trigger.assert_called_once()
+
+    @override_settings(DRF_MODEL_PUSHER_WEBHOOK_OPTIMISATION_ENABLED=True)
+    @mock.patch("pusher.Pusher.trigger")
+    def test_trigger_calls_pusher_trigger_when_channel_occupied(self, trigger: Mock):
+        cache.set("drf-model-pusher:occupied:my-channel", True)
+
+        provider = PusherProvider()
+        provider.trigger(["my-channel"], "myevent", {"foo": "bar"})
+        trigger.assert_called_once()
+
+    @override_settings(DRF_MODEL_PUSHER_WEBHOOK_OPTIMISATION_ENABLED=True)
+    @mock.patch("pusher.Pusher.trigger")
+    def test_trigger_does_not_call_pusher_trigger_when_channel_vacated(self, trigger: Mock):
+        cache.set("drf-model-pusher:occupied:my-channel", False)
+
+        provider = PusherProvider()
+        provider.trigger(["my-channel"], "myevent", {"foo": "bar"})
+        trigger.assert_not_called()
+
+    @override_settings(DRF_MODEL_PUSHER_WEBHOOK_OPTIMISATION_ENABLED=True)
+    @mock.patch("pusher.Pusher.channels_info")
+    @mock.patch("pusher.Pusher.trigger")
+    def test_trigger_syncs_cache_if_channel_does_not_exist_in_cache(self, trigger: Mock, channels_info: Mock):
+        channels_info.return_value = {"channels": {"my-channel": {}}}
+
+        provider = PusherProvider()
+        provider.trigger(["my-channel"], "myevent", {"foo": "bar"})
+
+        self.assertTrue(cache.get("drf-model-pusher:occupied:my-channel"))

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -15,7 +15,7 @@ class TestPusherProvider(TestCase):
     def test_trigger_calls_pusher_trigger(self, trigger: Mock):
         provider = PusherProvider()
         provider.trigger(["my-channel"], "myevent", {"foo": "bar"})
-        trigger.assert_called_once()
+        self.assertTrue(trigger.called)
 
     @override_settings(DRF_MODEL_PUSHER_WEBHOOK_OPTIMISATION_ENABLED=True)
     @mock.patch("pusher.Pusher.trigger")
@@ -24,7 +24,7 @@ class TestPusherProvider(TestCase):
 
         provider = PusherProvider()
         provider.trigger(["my-channel"], "myevent", {"foo": "bar"})
-        trigger.assert_called_once()
+        self.assertTrue(trigger.called)
 
     @override_settings(DRF_MODEL_PUSHER_WEBHOOK_OPTIMISATION_ENABLED=True)
     @mock.patch("pusher.Pusher.trigger")
@@ -33,7 +33,7 @@ class TestPusherProvider(TestCase):
 
         provider = PusherProvider()
         provider.trigger(["my-channel"], "myevent", {"foo": "bar"})
-        trigger.assert_not_called()
+        self.assertFalse(trigger.called)
 
     @override_settings(DRF_MODEL_PUSHER_WEBHOOK_OPTIMISATION_ENABLED=True)
     @mock.patch("pusher.Pusher.channels_info")

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -4,13 +4,13 @@ from unittest.mock import Mock
 from pytest import mark
 from rest_framework.test import APIRequestFactory
 
-from example.models import MyModel
-from example.serializers import MyModelSerializer
-from example.views import MyModelViewSet
+from example.models import MyPublicModel, MyPrivateModel, MyPresenceModel
+from example.serializers import MyPublicModelSerializer, MyPrivateModelSerializer, MyPresenceModelSerializer
+from example.views import MyPublicModelViewSet, MyPrivateModelViewSet, MyPresenceModelViewSet
 
 
 @mark.django_db
-class TestModelPusherViewMixin(TestCase):
+class TestModelPusherViewMixinPublicChannels(TestCase):
     """Integration tests between models, serializers, pusher backends, and views."""
 
     @mock.patch("pusher.Pusher.trigger")
@@ -19,50 +19,168 @@ class TestModelPusherViewMixin(TestCase):
         request_factory = APIRequestFactory()
         create_request = request_factory.post(path="/mymodels/", data={"name": "Henry"})
 
-        view = MyModelViewSet.as_view({"post": "create"})
+        view = MyPublicModelViewSet.as_view({"post": "create"})
         response = view(create_request)
-        instance = MyModel.objects.last()
+        instance = MyPublicModel.objects.last()
 
         self.assertEqual(response.status_code, 201, response.data)
 
         trigger.assert_called_once_with(
-            ["channel"], "mymodel.create", MyModelSerializer(instance=instance).data, None
+            ["channel"], "mypublicmodel.create", MyPublicModelSerializer(instance=instance).data, None
         )
 
     @mock.patch("pusher.Pusher.trigger")
     def test_updates_are_pushed(self, trigger: Mock):
-        instance = MyModel.objects.create(name="Julie")
+        instance = MyPublicModel.objects.create(name="Julie")
 
         request_factory = APIRequestFactory()
         partial_update_request = request_factory.patch(
             path="/mymodels/123/", data={"name": "Michelle"}
         )
 
-        view = MyModelViewSet.as_view({"patch": "partial_update"})
+        view = MyPublicModelViewSet.as_view({"patch": "partial_update"})
         response = view(partial_update_request, pk=instance.pk)
-        instance = MyModel.objects.last()
+        instance = MyPublicModel.objects.last()
 
         self.assertEqual(response.status_code, 200, response.data)
         self.assertEqual(instance.name, "Michelle")
 
         trigger.assert_called_once_with(
-            ["channel"], "mymodel.update", MyModelSerializer(instance=instance).data, None
+            ["channel"], "mypublicmodel.update", MyPublicModelSerializer(instance=instance).data, None
         )
 
     @mock.patch("pusher.Pusher.trigger")
     def test_deletions_are_pushed(self, trigger: Mock):
-        instance = MyModel.objects.create(name="Henry")
+        instance = MyPublicModel.objects.create(name="Henry")
 
         request_factory = APIRequestFactory()
         delete_request = request_factory.delete(path="/mymodels/1/")
 
-        view = MyModelViewSet.as_view({"delete": "destroy"})
+        view = MyPublicModelViewSet.as_view({"delete": "destroy"})
         response = view(delete_request, pk=instance.pk)
 
         self.assertEqual(response.status_code, 204, response.data)
-        with self.assertRaises(MyModel.DoesNotExist):
-            instance = MyModel.objects.get(pk=instance.pk)
+        with self.assertRaises(MyPublicModel.DoesNotExist):
+            instance = MyPublicModel.objects.get(pk=instance.pk)
 
         trigger.assert_called_once_with(
-            ["channel"], "mymodel.delete", MyModelSerializer(instance=instance).data, None
+            ["channel"], "mypublicmodel.delete", MyPublicModelSerializer(instance=instance).data, None
+        )
+
+
+@mark.django_db
+class TestModelPusherViewMixinPrivateChannels(TestCase):
+    """Integration tests between models, serializers, pusher backends, and views."""
+
+    @mock.patch("pusher.Pusher.trigger")
+    def test_creations_are_pushed(self, trigger: Mock):
+
+        request_factory = APIRequestFactory()
+        create_request = request_factory.post(path="/mymodels/", data={"name": "Henry"})
+
+        view = MyPrivateModelViewSet.as_view({"post": "create"})
+        response = view(create_request)
+        instance = MyPrivateModel.objects.last()
+
+        self.assertEqual(response.status_code, 201, response.data)
+
+        trigger.assert_called_once_with(
+            ["private-channel"], "myprivatemodel.create", MyPrivateModelSerializer(instance=instance).data, None
+        )
+
+    @mock.patch("pusher.Pusher.trigger")
+    def test_updates_are_pushed(self, trigger: Mock):
+        instance = MyPrivateModel.objects.create(name="Julie")
+
+        request_factory = APIRequestFactory()
+        partial_update_request = request_factory.patch(
+            path="/mymodels/123/", data={"name": "Michelle"}
+        )
+
+        view = MyPrivateModelViewSet.as_view({"patch": "partial_update"})
+        response = view(partial_update_request, pk=instance.pk)
+        instance = MyPrivateModel.objects.last()
+
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(instance.name, "Michelle")
+
+        trigger.assert_called_once_with(
+            ["private-channel"], "myprivatemodel.update", MyPrivateModelSerializer(instance=instance).data, None
+        )
+
+    @mock.patch("pusher.Pusher.trigger")
+    def test_deletions_are_pushed(self, trigger: Mock):
+        instance = MyPrivateModel.objects.create(name="Henry")
+
+        request_factory = APIRequestFactory()
+        delete_request = request_factory.delete(path="/mymodels/1/")
+
+        view = MyPrivateModelViewSet.as_view({"delete": "destroy"})
+        response = view(delete_request, pk=instance.pk)
+
+        self.assertEqual(response.status_code, 204, response.data)
+        with self.assertRaises(MyPrivateModel.DoesNotExist):
+            instance = MyPrivateModel.objects.get(pk=instance.pk)
+
+        trigger.assert_called_once_with(
+            ["private-channel"], "myprivatemodel.delete", MyPrivateModelSerializer(instance=instance).data, None
+        )
+
+
+@mark.django_db
+class TestModelPusherViewMixinPresenceChannels(TestCase):
+    """Integration tests between models, serializers, pusher backends, and views."""
+
+    @mock.patch("pusher.Pusher.trigger")
+    def test_creations_are_pushed(self, trigger: Mock):
+
+        request_factory = APIRequestFactory()
+        create_request = request_factory.post(path="/mymodels/", data={"name": "Henry"})
+
+        view = MyPresenceModelViewSet.as_view({"post": "create"})
+        response = view(create_request)
+        instance = MyPresenceModel.objects.last()
+
+        self.assertEqual(response.status_code, 201, response.data)
+
+        trigger.assert_called_once_with(
+            ["presence-channel"], "mypresencemodel.create", MyPresenceModelSerializer(instance=instance).data, None
+        )
+
+    @mock.patch("pusher.Pusher.trigger")
+    def test_updates_are_pushed(self, trigger: Mock):
+        instance = MyPresenceModel.objects.create(name="Julie")
+
+        request_factory = APIRequestFactory()
+        partial_update_request = request_factory.patch(
+            path="/mymodels/123/", data={"name": "Michelle"}
+        )
+
+        view = MyPresenceModelViewSet.as_view({"patch": "partial_update"})
+        response = view(partial_update_request, pk=instance.pk)
+        instance = MyPresenceModel.objects.last()
+
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(instance.name, "Michelle")
+
+        trigger.assert_called_once_with(
+            ["presence-channel"], "mypresencemodel.update", MyPresenceModelSerializer(instance=instance).data, None
+        )
+
+    @mock.patch("pusher.Pusher.trigger")
+    def test_deletions_are_pushed(self, trigger: Mock):
+        instance = MyPresenceModel.objects.create(name="Henry")
+
+        request_factory = APIRequestFactory()
+        delete_request = request_factory.delete(path="/mymodels/1/")
+
+        view = MyPresenceModelViewSet.as_view({"delete": "destroy"})
+        response = view(delete_request, pk=instance.pk)
+
+        self.assertEqual(response.status_code, 204, response.data)
+        with self.assertRaises(MyPresenceModel.DoesNotExist):
+            instance = MyPresenceModel.objects.get(pk=instance.pk)
+
+        trigger.assert_called_once_with(
+            ["presence-channel"], "mypresencemodel.delete", MyPresenceModelSerializer(instance=instance).data, None
         )

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,7 +1,9 @@
 from unittest import TestCase, mock
 from unittest.mock import Mock
 
+from django.core.cache import cache
 from pytest import mark
+from rest_framework import status
 from rest_framework.test import APIRequestFactory
 
 from drf_model_pusher.views import ChannelExistenceWebhook
@@ -210,3 +212,111 @@ class TestChannelExistenceWebhook(TestCase):
         view = ChannelExistenceWebhook().as_view()
         response = view(create_request)
         validate_webhook.assert_called_once()
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    @mock.patch("pusher.Pusher.validate_webhook")
+    def test_occupied_channel_stored_in_cache(self, validate_webhook: Mock):
+        data = {
+            "time_ms": 123456789,
+            "events": [
+                {"name": "channel_occupied", "channel": "my-channel"}
+            ]
+        }
+
+        headers = dict(
+            HTTP_X_PUSHER_KEY="123456789",
+            HTTP_X_PUSHER_SIGNATURE="123456789"
+        )
+
+        request_factory = APIRequestFactory()
+        create_request = request_factory.post(path="/pusher/channel-existence/", data=data, **headers)
+        view = ChannelExistenceWebhook().as_view()
+        response = view(create_request)
+        validate_webhook.assert_called_once()
+
+        self.assertTrue(cache.get("drf-model-pusher:occupied:my-channel"))
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    @mock.patch("pusher.Pusher.validate_webhook")
+    def test_multiple_occupied_channels_stored_in_cache(self, validate_webhook: Mock):
+        data = {
+            "time_ms": 123456789,
+            "events": [
+                {"name": "channel_occupied", "channel": "my-channel-1"},
+                {"name": "channel_occupied", "channel": "my-channel-2"}
+            ]
+        }
+
+        headers = dict(
+            HTTP_X_PUSHER_KEY="123456789",
+            HTTP_X_PUSHER_SIGNATURE="123456789"
+        )
+
+        request_factory = APIRequestFactory()
+        create_request = request_factory.post(path="/pusher/channel-existence/", data=data, **headers)
+        view = ChannelExistenceWebhook().as_view()
+        response = view(create_request)
+        validate_webhook.assert_called_once()
+
+        self.assertTrue(cache.get("drf-model-pusher:occupied:my-channel-1"))
+        self.assertTrue(cache.get("drf-model-pusher:occupied:my-channel-2"))
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    @mock.patch("pusher.Pusher.validate_webhook")
+    def test_occupied_channel_vacated_in_cache(self, validate_webhook: Mock):
+        data = {
+            "time_ms": 123456789,
+            "events": [
+                {"name": "channel_occupied", "channel": "my-channel"}
+            ]
+        }
+
+        headers = dict(
+            HTTP_X_PUSHER_KEY="123456789",
+            HTTP_X_PUSHER_SIGNATURE="123456789"
+        )
+
+        request_factory = APIRequestFactory()
+        create_request = request_factory.post(path="/pusher/channel-existence/", data=data, **headers)
+        view = ChannelExistenceWebhook().as_view()
+        response = view(create_request)
+        validate_webhook.assert_called_once()
+
+        self.assertTrue(cache.get("drf-model-pusher:occupied:my-channel"))
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        data = {
+            "time_ms": 123456789,
+            "events": [
+                {"name": "channel_vacated", "channel": "my-channel"}
+            ]
+        }
+
+        create_request = request_factory.post(path="/pusher/channel-existence/", data=data, **headers)
+        response = view(create_request)
+
+        self.assertIsNone(cache.get("drf-model-pusher:occupied:my-channel"))
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    @mock.patch("pusher.Pusher.validate_webhook")
+    def test_vacate_channel_when_not_in_cache(self, validate_webhook: Mock):
+        data = {
+            "time_ms": 123456789,
+            "events": [
+                {"name": "channel_vacated", "channel": "my-channel"}
+            ]
+        }
+
+        headers = dict(
+            HTTP_X_PUSHER_KEY="123456789",
+            HTTP_X_PUSHER_SIGNATURE="123456789"
+        )
+
+        request_factory = APIRequestFactory()
+        create_request = request_factory.post(path="/pusher/channel-existence/", data=data, **headers)
+        view = ChannelExistenceWebhook().as_view()
+        response = view(create_request)
+        validate_webhook.assert_called_once()
+
+        self.assertIsNone(cache.get("drf-model-pusher:occupied:my-channel"))
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -213,7 +213,8 @@ class TestChannelExistenceWebhook(TestCase):
         create_request = request_factory.post(path="/pusher/channel-existence/", data=data, **headers)
         view = ChannelExistenceWebhook().as_view()
         response = view(create_request)
-        validate_webhook.assert_called_once()
+
+        self.assertTrue(validate_webhook.called)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     @mock.patch("pusher.Pusher.validate_webhook")
@@ -234,8 +235,8 @@ class TestChannelExistenceWebhook(TestCase):
         create_request = request_factory.post(path="/pusher/channel-existence/", data=data, **headers)
         view = ChannelExistenceWebhook().as_view()
         response = view(create_request)
-        validate_webhook.assert_called_once()
 
+        self.assertTrue(validate_webhook.called)
         self.assertTrue(cache.get("drf-model-pusher:occupied:my-channel"))
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
@@ -258,8 +259,8 @@ class TestChannelExistenceWebhook(TestCase):
         create_request = request_factory.post(path="/pusher/channel-existence/", data=data, **headers)
         view = ChannelExistenceWebhook().as_view()
         response = view(create_request)
-        validate_webhook.assert_called_once()
 
+        self.assertTrue(validate_webhook.called)
         self.assertTrue(cache.get("drf-model-pusher:occupied:my-channel-1"))
         self.assertTrue(cache.get("drf-model-pusher:occupied:my-channel-2"))
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -282,8 +283,8 @@ class TestChannelExistenceWebhook(TestCase):
         create_request = request_factory.post(path="/pusher/channel-existence/", data=data, **headers)
         view = ChannelExistenceWebhook().as_view()
         response = view(create_request)
-        validate_webhook.assert_called_once()
 
+        self.assertTrue(validate_webhook.called)
         self.assertTrue(cache.get("drf-model-pusher:occupied:my-channel"))
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
@@ -318,7 +319,7 @@ class TestChannelExistenceWebhook(TestCase):
         create_request = request_factory.post(path="/pusher/channel-existence/", data=data, **headers)
         view = ChannelExistenceWebhook().as_view()
         response = view(create_request)
-        validate_webhook.assert_called_once()
 
+        self.assertTrue(validate_webhook.called)
         self.assertFalse(cache.get("drf-model-pusher:occupied:my-channel"))
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -192,6 +192,8 @@ class TestModelPusherViewMixinPresenceChannels(TestCase):
 @mark.django_db
 class TestChannelExistenceWebhook(TestCase):
     """Test the ChannelExistenceWebhook"""
+    def tearDown(self):
+        cache.clear()
 
     @mock.patch("pusher.Pusher.validate_webhook")
     def test_auth_is_successful(self, validate_webhook: Mock):
@@ -295,7 +297,7 @@ class TestChannelExistenceWebhook(TestCase):
         create_request = request_factory.post(path="/pusher/channel-existence/", data=data, **headers)
         response = view(create_request)
 
-        self.assertIsNone(cache.get("drf-model-pusher:occupied:my-channel"))
+        self.assertFalse(cache.get("drf-model-pusher:occupied:my-channel"))
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     @mock.patch("pusher.Pusher.validate_webhook")
@@ -318,5 +320,5 @@ class TestChannelExistenceWebhook(TestCase):
         response = view(create_request)
         validate_webhook.assert_called_once()
 
-        self.assertIsNone(cache.get("drf-model-pusher:occupied:my-channel"))
+        self.assertFalse(cache.get("drf-model-pusher:occupied:my-channel"))
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -185,37 +185,3 @@ class TestModelPusherViewMixinPresenceChannels(TestCase):
         trigger.assert_called_once_with(
             ["presence-channel"], "mypresencemodel.delete", MyPresenceModelSerializer(instance=instance).data, None
         )
-
-    @mock.patch("pusher.Pusher.trigger")
-    @mock.patch("pusher.Pusher.channel_info")
-    @override_settings(DRF_MODEL_PUSHER_OPTIMISE_PRESENCE_EVENTS=True)
-    def test_creations_are_pushed_when_optimised_events_are_on(self, channel_info: Mock, trigger: Mock):
-        request_factory = APIRequestFactory()
-        create_request = request_factory.post(path="/mymodels/", data={"name": "Henry"})
-
-        channel_info.return_value = {"user_count": 1}
-
-        view = MyPresenceModelViewSet.as_view({"post": "create"})
-        response = view(create_request)
-        instance = MyPresenceModel.objects.last()
-
-        self.assertEqual(response.status_code, 201, response.data)
-
-        trigger.assert_called_once_with(
-            ["presence-channel"], "mypresencemodel.create", MyPresenceModelSerializer(instance=instance).data, None
-        )
-
-    @mock.patch("pusher.Pusher.trigger")
-    @mock.patch("pusher.Pusher.channel_info")
-    @override_settings(DRF_MODEL_PUSHER_OPTIMISE_PRESENCE_EVENTS=True)
-    def test_creations_are_not_pushed_when_optimised_events_are_on(self, channel_info: Mock, trigger: Mock):
-        request_factory = APIRequestFactory()
-        create_request = request_factory.post(path="/mymodels/", data={"name": "Henry"})
-
-        channel_info.return_value = {"user_count": 0}
-
-        view = MyPresenceModelViewSet.as_view({"post": "create"})
-        response = view(create_request)
-
-        self.assertEqual(response.status_code, 201, response.data)
-        trigger.assert_not_called()


### PR DESCRIPTION
Fixes #40 
Includes #39 

This PR implements the plan from #40 and has worked well in local testing. The only extra information I have found since writing the plan is that Pusher occasionally delays `channel_vacated` events on the webhook to combat network interruptions. This may lead to small amounts of events that get sent when no one is in a channel but will still be significantly smaller than without the optimisation in applications that send large volumes of events. 