### PR TITLE
improvement: django 4 support for Signal

### DIFF
--- a/drf_model_pusher/signals.py
+++ b/drf_model_pusher/signals.py
@@ -1,10 +1,6 @@
 from django.dispatch import Signal
 
 
-view_post_save = Signal(
-    providing_args=["instance", "channels", "event_name", "data", "socket_id"]
-)
+view_post_save = Signal()
 
-view_pre_destroy = Signal(
-    providing_args=["instance", "channels", "event_name", "data", "socket_id"]
-)
+view_pre_destroy = Signal()


### PR DESCRIPTION
Implements https://github.com/aljp/drf_model_pusher/issues/58 to add support for Django 4 by refactoring the use of `Signal`.